### PR TITLE
feat: scale load/discharge speed proportionally to capacity changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The mod supports multiplayer with a permission system:
 ### 0.3.4.0 (Alpha)
 
 - Fixed K keybind for placeables getting stuck when entering vehicles
+- Scaled load/discharge speed proportionally to capacity change from original capacity
 
 ### 0.3.3.0 (Alpha)
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -39,6 +39,7 @@ Console commands available.
 Changelog:
 0.3.4.0 (Alpha):
 - Fixed K keybind for placeables getting stuck when entering vehicles
+- Scaled load/discharge speed proportionally to capacity change from original capacity
 
 0.3.3.0 (Alpha):
 - Fixed fill levels being lost when loading savegames with expanded capacity

--- a/scripts/placeables/RmPlaceableStorageCapacity.lua
+++ b/scripts/placeables/RmPlaceableStorageCapacity.lua
@@ -93,6 +93,10 @@ function RmPlaceableStorageCapacity:onLoad(savegame)
     Log:debug("onLoad: %s (uniqueId=%s, ownerFarmId=%s)",
         placeableName, tostring(self.uniqueId), tostring(ownerFarmId))
 
+    -- CRITICAL: Capture original capacities BEFORE applying custom capacities
+    -- This ensures we have the true original values for speed scaling calculations
+    RmAdjustStorageCapacity:captureOriginalCapacities(self)
+
     -- Load and apply custom capacity from savegame (server only)
     -- This MUST happen in onLoad, BEFORE PlaceableSilo:loadFromXMLFile loads fill levels
     if g_server ~= nil and savegame ~= nil then
@@ -178,9 +182,8 @@ function RmPlaceableStorageCapacity:onPostLoad(savegame)
         return
     end
 
-    -- Capture original capacity before any ReadStream modifications
-    -- This must happen here (not in onMissionStarted) because ReadStream runs before mission start
-    RmAdjustStorageCapacity:captureOriginalCapacities(self)
+    -- Note: Original capacities are now captured in onLoad() BEFORE custom capacities are applied
+    -- This ensures the true original values are captured for speed scaling calculations
 
     local ownerFarmId = self:getOwnerFarmId()
     Log:debug("onPostLoad complete: %s (uniqueId=%s, ownerFarmId=%s, storage types: %s)",


### PR DESCRIPTION
When storage capacity is modified, automatically scale the loading and discharge speeds proportionally. Example: 8000L -> 80000L (10x) means speed also becomes 10x faster.

Placeables (silos, productions, husbandries):
- Capture original loadTrigger.fillLitersPerMS on load
- Apply proportional speed via getMaxCapacityMultiplier()
- Reset speed when capacity is reset to original

Vehicles (trailers, tankers):
- Capture original dischargeNode.emptySpeed on load
- Apply proportional speed when capacity changes
- Reset speed when capacity is reset to original

Fixes #6