### PR TITLE
fix: Mod blocks keybinding for the wrench at the production point

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ The mod supports multiplayer with a permission system:
 
 ## Changelog
 
+### 0.4.1.0 (Beta)
+
+- Fixed production point menu (R) not showing when K keybind is active
+
 ### 0.4.0.0 (Beta)
 
 - Visual fill levels now update when changing capacity

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="100">
     <author>Ritter</author>
-    <version>0.4.0.0</version>
+    <version>0.4.1.0</version>
     <title>
         <en>Adjust Storage Capacity</en>
     </title>
@@ -37,6 +37,9 @@ Not Supported:
 Console commands available.
 
 Changelog:
+
+0.4.1.0 (Beta):
+- Fixed production point menu (R) not showing when K keybind is active
 
 0.4.0.0 (Beta):
 - Visual fill levels now update when changing capacity


### PR DESCRIPTION
Special handling for production points that for some reason sets themselves to the lowest possible priority.

Added dynamic yield in getIsActivatable() - returns false when player is within 1.5m of PP's interaction trigger, letting the native PP activatable take priority.

Fixes #12