### PR TITLE
Refresh vehicle speed and mass after capacity changes

### DIFF
--- a/scripts/RmAdjustStorageCapacity.lua
+++ b/scripts/RmAdjustStorageCapacity.lua
@@ -1940,9 +1940,13 @@ function RmAdjustStorageCapacity:applyVehicleCapacity(vehicle, fillUnitIndex, ca
 
     -- Apply proportional discharge speed
     local spec = vehicle[RmVehicleStorageCapacity.SPEC_TABLE_NAME]
-    if spec ~= nil and spec.applyProportionalDischargeSpeed ~= nil then
-        -- Call via method on the vehicle/spec
+    if spec ~= nil then
         RmVehicleStorageCapacity.applyProportionalDischargeSpeed(vehicle, fillUnitIndex, capacity)
+    end
+
+    -- Capacity affects the additional-mass calculation, so discard the cached value.
+    if vehicle.setMassDirty ~= nil then
+        vehicle:setMassDirty()
     end
 
     -- Update FillVolume cached capacity for visual representation


### PR DESCRIPTION
Changing a vehicle’s capacity at runtime updated the fill unit, but the follow-up discharge-speed check looked for `applyProportionalDischargeSpeed` on the specialization data table. That table only contains per-vehicle state, so the check always failed. Discharge speed was not updated until another path reapplied it, such as reloading the vehicle or toggling the setting.

Capacity changes also left the cached component mass unchanged until another fill operation marked it dirty.

This calls the existing discharge-speed helper whenever the vehicle has the specialization and marks component mass dirty after applying a capacity change. The existing original capacity and speed values remain the baseline, so repeated changes do not compound.

Tested with Lua syntax checks, XML validation, and local checks covering repeated capacity changes, discharge-speed scaling, reset behavior, mass invalidation, and mass scaling.

This has not been tested in a live game session.
