### PR TITLE
Keep multiplayer settings under server control

### DIFF
--- a/scripts/RmAscSettings.lua
+++ b/scripts/RmAscSettings.lua
@@ -26,6 +26,21 @@ function RmAscSettings.isShortcutEnabled()
     return RmAscSettings.showTriggerShortcutState == 2
 end
 
+--- Check whether the local player may change shared settings
+---@return boolean
+function RmAscSettings.canChangeSettings()
+    if g_currentMission == nil then
+        return false
+    end
+
+    local missionInfo = g_currentMission.missionDynamicInfo
+    if missionInfo == nil or not missionInfo.isMultiplayer then
+        return true
+    end
+
+    return g_currentMission:getIsServer() or g_currentMission.isMasterUser == true
+end
+
 -- ============================================================================
 -- GUI Initialization
 -- ============================================================================
@@ -168,9 +183,13 @@ end
 -- ============================================================================
 
 --- Called when BinaryOption is clicked
----@param _ table element (unused)
+---@param element table BinaryOption element
 ---@param state number New state (1 = OFF, 2 = ON)
-function RmAscSettings.onToggleChanged(_, state)
+function RmAscSettings.onToggleChanged(element, state)
+    if not RmAscSettings.canChangeSettings() then
+        element:setState(RmAscSettings.showTriggerShortcutState)
+        return
+    end
     RmAscSettings.updateShowTriggerShortcut(state)
 end
 
@@ -188,9 +207,13 @@ function RmAscSettings.updateShowTriggerShortcut(state, noEventSend)
 end
 
 --- Called when auto-scale mass BinaryOption is clicked
----@param _ table element (unused)
+---@param element table BinaryOption element
 ---@param state number New state (1 = OFF, 2 = ON)
-function RmAscSettings.onAutoScaleMassChanged(_, state)
+function RmAscSettings.onAutoScaleMassChanged(element, state)
+    if not RmAscSettings.canChangeSettings() then
+        element:setState(RmAscSettings.autoScaleMassState)
+        return
+    end
     RmAscSettings.updateAutoScaleMass(state)
 end
 
@@ -231,9 +254,13 @@ function RmAscSettings.dirtyAllVehicleMass()
 end
 
 --- Called when auto-scale speed BinaryOption is clicked
----@param _ table element (unused)
+---@param element table BinaryOption element
 ---@param state number New state (1 = OFF, 2 = ON)
-function RmAscSettings.onAutoScaleSpeedChanged(_, state)
+function RmAscSettings.onAutoScaleSpeedChanged(element, state)
+    if not RmAscSettings.canChangeSettings() then
+        element:setState(RmAscSettings.autoScaleSpeedState)
+        return
+    end
     RmAscSettings.updateAutoScaleSpeed(state)
 end
 
@@ -311,19 +338,24 @@ end
 --- Called via updateGameSettings hook when settings frame opens
 ---@param settingsPage table InGameMenuSettingsFrame instance
 function RmAscSettings.updateGameSettings(settingsPage)
+    local canChange = RmAscSettings.canChangeSettings()
+
     local element = settingsPage.rmAscShowTriggerShortcut
     if element ~= nil then
         element:setState(RmAscSettings.showTriggerShortcutState)
+        element:setDisabled(not canChange)
     end
 
     local massElement = settingsPage.rmAscAutoScaleMass
     if massElement ~= nil then
         massElement:setState(RmAscSettings.autoScaleMassState)
+        massElement:setDisabled(not canChange)
     end
 
     local speedElement = settingsPage.rmAscAutoScaleSpeed
     if speedElement ~= nil then
         speedElement:setState(RmAscSettings.autoScaleSpeedState)
+        speedElement:setDisabled(not canChange)
     end
 end
 

--- a/scripts/events/RmSettingsSyncEvent.lua
+++ b/scripts/events/RmSettingsSyncEvent.lua
@@ -41,7 +41,8 @@ function RmSettingsSyncEvent:readStream(streamId, connection)
             g_server:broadcastEvent(self, false, connection)
         end
     else
-        Log:warning("RmSettingsSyncEvent: Rejected - not server or master user")
+        Log:warning("RmSettingsSyncEvent: Rejected settings change from non-admin client")
+        connection:sendEvent(RmSettingsSyncEvent.new())
     end
 end
 


### PR DESCRIPTION
Ordinary multiplayer clients could change the shared settings from the game settings page. The server rejected those events, but the client had already changed its local state and did not receive the accepted values back. This could leave shortcut visibility, mass scaling, or speed scaling different on that client.

This makes the three shared controls read-only for non-admin multiplayer clients and prevents their callbacks from changing local state. If an unauthorized settings event still reaches the server, the server now returns its current settings to that connection without broadcasting the rejected change.

Single-player, server-host, and remote-admin behavior is unchanged.

Tested with Lua syntax checks, XML validation, and local multiplayer checks covering UI permissions, rejected callbacks, accepted admin changes, server rejection, corrective serialization, and broadcast behavior.

This has not been tested in a live multiplayer session.
